### PR TITLE
CASMCMS-7232: Make Bash scripts more Mac-friendly and more consistent with one another

### DIFF
--- a/copyright_license_check/copyright_license_check.sh
+++ b/copyright_license_check/copyright_license_check.sh
@@ -28,22 +28,39 @@
 
 TMPFILE1=/tmp/.copyright_license_check.$$.$RANDOM.tmp.1
 TMPFILE2=/tmp/.copyright_license_check.$$.$RANDOM.tmp.2
+CLC_CONF="copyright_license_check.yaml"
+MYDIR="copyright_license_check"
+MYNAME="copyright_license_check.sh"
 
-function scan_file {
+function info
+{
+    echo "$MYNAME: $*"
+}
+
+function err_exit
+{
+    info "ERROR: $*" 1>&2
+    exit 1
+}
+
+function scan_file
+{
+    local prefix="Copyright[[:space:]]"
+    local year="(19|20)[0-9][0-9]"
     echo -n "Scanning $1... "
     # skip empty files
     if [ -s "$1" ]; then
         local -i missing
         missing=0
         echo -n "copyright... "
-        if ! grep -Eq "Copyright[[:space:]]" "$1" ; then
+        if ! grep -Eq "$prefix" "$1" ; then
             echo -n "missing"
             missing=1
         # We allow for the copyright years to be surrounded by brackets, or not
-        elif ! grep -Eq "Copyright[[:space:]](|\[)(19|20)[0-9][0-9]" "$1" ; then
+        elif ! grep -Eq "(${prefix}|${prefix}\[)${year}" "$1" ; then
             echo -n "missing year"
             missing=1
-        elif ! grep -Eq "Copyright[[:space:]](|\[)(19|20)[0-9][0-9].*[[:space:]]Hewlett Packard Enterprise Development LP" "$1" ; then
+        elif ! grep -Eq "(${prefix}|${prefix}\[)${year}.*[[:space:]]Hewlett Packard Enterprise Development LP" "$1" ; then
             echo -n "missing/incorrect company name"
             missing=1
         else
@@ -62,79 +79,102 @@ function scan_file {
     return 0
 }
 
-CLC_CONF="copyright_license_check.yaml"
+function run_cmd_verify_dir
+{
+    out=$("$@") || err_exit "Command failed: $*"
+    [ -n "$out" ] || err_exit "Command gave blank outut: $*"
+    [ -e "$out" ] || err_exit "Nonexistent path ($out) given by command: $*"
+    [ -d "$out" ] || err_exit "Non-directory path ($out) given by command: $*"
+}
+
+[ -n "${CMS_META_TOOLS_PATH}" ] && info "CMS_META_TOOLS_PATH is set to $CMS_META_TOOLS_PATH"
+
+# If CMS_META_TOOLS_PATH variable is set to a valid value, we will defer to that
+if [ -n "${CMS_META_TOOLS_PATH}" ] && [ -f "${CMS_META_TOOLS_PATH}/${MYDIR}/${MYNAME}" ]; then
+    info "Using value from CMS_META_TOOLS_PATH variable"
+    MYDIR_PATH="${CMS_META_TOOLS_PATH}/${MYDIR}"
+# In this case, let's first try realpath, since it gives us the cleanest paths
+elif realpath / >/dev/null 2>&1 ; then
+    # realpath is available, so let's use that
+    run_cmd_verify_dir dirname "$0"
+    run_cmd_verify_dir realpath "$out"
+    MYDIR_PATH="$out"
+    # Export CMS_META_TOOLS_PATH environment variable so any other scripts we call
+    # can use it, rather than repeating this stuff
+    run_cmd_verify_dir realpath "${MYDIR_PATH}/.."
+    export CMS_META_TOOLS_PATH="$out"
+    info "Exported CMS_META_TOOLS_PATH as '${CMS_META_TOOLS_PATH}'"
+# Backup plan is to use BASH_SOURCE, but note that MacOS in particular does not support this
+elif [ -n "${BASH_SOURCE[0]}" ]; then
+    run_cmd_verify_dir dirname "${BASH_SOURCE[0]}"
+    MYDIR_PATH="$out"
+    # Export CMS_META_TOOLS_PATH environment variable so any other scripts we call
+    # can use it, rather than repeating this stuff
+    export CMS_META_TOOLS_PATH="${MYDIR_PATH}/.."
+    info "Exported CMS_META_TOOLS_PATH as '${CMS_META_TOOLS_PATH}'"
+else
+    info "realpath and BASH_SOURCE both unavailable"
+    err_exit "Unable to determine path to cms-meta-tools"
+fi
+[ -f "${MYDIR_PATH}/$MYNAME" ] || err_exit "$MYNAME not found in directory ${MYDIR_PATH}"
+
+info "clc should be located in directory $MYDIR_PATH"
 
 # Default config file should be located in the same directory as this script
-CLC_DIR=$(dirname ${BASH_SOURCE[0]})
-echo "clc should be located in directory $CLC_DIR"
-DEFAULT_CLC_CONF="$CLC_DIR/$CLC_CONF"
+DEFAULT_CLC_CONF="${MYDIR_PATH}/${CLC_CONF}"
 if [ -s "$DEFAULT_CLC_CONF" ]; then
-    echo "Located default clc config file: $DEFAULT_CLC_CONF"
+    info "Located default clc config file: $DEFAULT_CLC_CONF"
 else
     if [ -f "$DEFAULT_CLC_CONF" ]; then
-        echo "File is zero size: $DEFAULT_CLC_CONF"
+        info "File is zero size: $DEFAULT_CLC_CONF"
     elif [ -e "$DEFAULT_CLC_CONF" ]; then
-        echo "Exists but is not a file: $DEFAULT_CLC_CONF"
-    elif [ -d "$CLC_DIR" ]; then
-        echo "$CLC_DIR directory exists but does not contain $CLC_CONF"
-    elif [ -e "$CLC_DIR" ]; then
-        echo "$CLC_DIR exists but is not a directory"
-    else
-        echo "Does not exist: $CLC_DIR"
+        info "Exists but is not a file: $DEFAULT_CLC_CONF"
     fi
-    echo "BASH_SOURCE = ${BASH_SOURCE[*]}"
-    echo "ERROR: Unable to locate clc directory and/or config file $CLC_CONF" 1>&2
-    exit 1
+    err_exit "Unable to locate clc directory and/or config file $CLC_CONF"
 fi
 
 REPO_CLC_CONF=./$CLC_CONF
 if [ -f "$REPO_CLC_CONF" ]; then
-    echo "Found repo clc config file: $REPO_CLC_CONF"
+    info "Found repo clc config file: $REPO_CLC_CONF"
 else
-    echo "No repo-specific clc config file. Default only will be used."
+    info "No repo-specific clc config file. Default only will be used."
     REPO_CLC_CONF=""
 fi
 
 FF_SH="file_filter.sh"
 # file_filter script should be in a sibling directory to this one
-FF_DIR="$CLC_DIR/../file_filter"
+FF_DIR="${CMS_META_TOOLS_PATH}/file_filter"
 FF_TARGETS="$FF_DIR/$FF_SH"
 if [ -x "$FF_TARGETS" ] && [ -s "$FF_TARGETS" ]; then
-    echo "Located $FF_SH in $FF_DIR"
+    info "Located $FF_SH in $FF_DIR"
 else
     if [ -x "$FF_TARGETS" ]; then
-        echo "File is zero size: $FF_TARGETS"
+        err_exit "File is zero size: $FF_TARGETS"
     elif [ -s "$FF_TARGETS" ]; then
-        echo "File is not executable: $FF_TARGETS"
+        err_exit "File is not executable: $FF_TARGETS"
     elif [ -f "$FF_TARGETS" ]; then
-        echo "File is zero size and not executable: $FF_TARGETS"
+        err_exit "File is zero size and not executable: $FF_TARGETS"
     elif [ -e "$FF_TARGETS" ]; then
-        echo "Exists but is not a file: $FF_TARGETS"
+        err_exit "Exists but is not a file: $FF_TARGETS"
     elif [ -d "$FF_DIR" ]; then
-        echo "Does not exist: $FF_TARGETS"
+        err_exit "Does not exist: $FF_TARGETS"
     elif [ -e "$FF_DIR" ]; then
-        echo "Exists but is not a directory: $FF_DIR"
-    else
-        echo "Does not exist: $FF_DIR"
+        err_exit "Exists but is not a directory: $FF_DIR"
     fi
-    echo "BASH_SOURCE = ${BASH_SOURCE[*]}"
-    echo "ERROR: Problem with $FF_SH in $FF_DIR directory." 1>&2
-    exit 1
+    err_exit "Does not exist: $FF_DIR"
 fi
 
 if ! git ls-files --empty-directory > $TMPFILE1 ; then
-    echo "ERROR: Command failed:  git ls-files --empty-directory" 1>&2
     rm -f $TMPFILE1 >/dev/null 2>&1
-    exit 1
+    err_exit "Command failed:  git ls-files --empty-directory"
 fi
 
 # $REPO_CLC_CONF not in quotes because we know it has no whitespace and because if it is
 # blank (meaning there is no repo clc config file), we do not want it passed as an empty
 # string argument
 if ! cat $TMPFILE1 | "$FF_TARGETS" "$DEFAULT_CLC_CONF" $REPO_CLC_CONF > $TMPFILE2 ; then
-    echo "ERROR: $FF_TARGETS failed" 1>&2
     rm -f $TMPFILE1 $TMPFILE2 >/dev/null 2>&1
-    exit 1
+    err_exit "$FF_TARGETS failed"
 fi
 
 FAIL=0
@@ -148,9 +188,8 @@ EOF
 rm -f $TMPFILE1 $TMPFILE2 >/dev/null 2>&1
 
 if [ $FAIL -eq 0 ]; then
-    echo "All scanned code passed"
-else
-    echo "Some code is missing proper copyright or license, see list above" 1>&2
+    info "All scanned code passed"
+    exit 0
 fi
 
-exit $FAIL
+err_exit "Some code is missing proper copyright or license, see list above"

--- a/go_lint/go_lint.sh
+++ b/go_lint/go_lint.sh
@@ -23,14 +23,29 @@
 # (MIT License)
 
 # Very simple scanner for Go files which runs the gofmt linter on them
-# 
+#
 # It should be called from the root of the target repo
 # Usage: go_lint.sh
 
 TMPFILE1=/tmp/.go_lint.$$.$RANDOM.tmp.1
 TMPFILE2=/tmp/.go_lint.$$.$RANDOM.tmp.2
+GL_CONF="go_lint.yaml"
+MYDIR="go_lint"
+MYNAME="go_lint.sh"
 
-function scan_file {
+function info
+{
+    echo "$MYNAME: $*"
+}
+
+function err_exit
+{
+    info "ERROR: $*" 1>&2
+    exit 1
+}
+
+function scan_file
+{
     local out
     local rc
     echo -n "Scanning $1 with gofmt... "
@@ -53,81 +68,106 @@ function scan_file {
     return 0
 }
 
-GL_CONF="go_lint.yaml"
+function run_cmd_verify_dir
+{
+    out=$("$@") || err_exit "Command failed: $*"
+    [ -n "$out" ] || err_exit "Command gave blank outut: $*"
+    [ -e "$out" ] || err_exit "Nonexistent path ($out) given by command: $*"
+    [ -d "$out" ] || err_exit "Non-directory path ($out) given by command: $*"
+}
+
+[ -n "${CMS_META_TOOLS_PATH}" ] && info "CMS_META_TOOLS_PATH is set to $CMS_META_TOOLS_PATH"
+
+# If CMS_META_TOOLS_PATH variable is set to a valid value, we will defer to that
+if [ -n "${CMS_META_TOOLS_PATH}" ] && [ -f "${CMS_META_TOOLS_PATH}/${MYDIR}/${MYNAME}" ]; then
+    info "Using value from CMS_META_TOOLS_PATH variable"
+    MYDIR_PATH="${CMS_META_TOOLS_PATH}/${MYDIR}"
+# In this case, let's first try realpath, since it gives us the cleanest paths
+elif realpath / >/dev/null 2>&1 ; then
+    # realpath is available, so let's use that
+    run_cmd_verify_dir dirname "$0"
+    run_cmd_verify_dir realpath "$out"
+    MYDIR_PATH="$out"
+    # Export CMS_META_TOOLS_PATH environment variable so any other scripts we call
+    # can use it, rather than repeating this stuff
+    run_cmd_verify_dir realpath "${MYDIR_PATH}/.."
+    export CMS_META_TOOLS_PATH="$out"
+    info "Exported CMS_META_TOOLS_PATH as '${CMS_META_TOOLS_PATH}'"
+# Backup plan is to use BASH_SOURCE, but note that MacOS in particular does not support this
+elif [ -n "${BASH_SOURCE[0]}" ]; then
+    run_cmd_verify_dir dirname "${BASH_SOURCE[0]}"
+    MYDIR_PATH="$out"
+    # Export CMS_META_TOOLS_PATH environment variable so any other scripts we call
+    # can use it, rather than repeating this stuff
+    export CMS_META_TOOLS_PATH="${MYDIR_PATH}/.."
+    info "Exported CMS_META_TOOLS_PATH as '${CMS_META_TOOLS_PATH}'"
+else
+    info "realpath and BASH_SOURCE both unavailable"
+    err_exit "Unable to determine path to cms-meta-tools"
+fi
+[ -f "${MYDIR_PATH}/$MYNAME" ] || err_exit "$MYNAME not found in directory ${MYDIR_PATH}"
+
+info "go_lint is be located in directory $MYDIR_PATH"
 
 # Default config file should be located in the same directory as this script
-GL_DIR=$(dirname ${BASH_SOURCE[0]})
-echo "gl should be located in directory $GL_DIR"
-DEFAULT_GL_CONF="$GL_DIR/$GL_CONF"
+DEFAULT_GL_CONF="$MYDIR_PATH/$GL_CONF"
 if [ -s "$DEFAULT_GL_CONF" ]; then
-    echo "Located default gl config file: $DEFAULT_GL_CONF"
+    info "Located default gl config file: $DEFAULT_GL_CONF"
 else
     if [ -f "$DEFAULT_GL_CONF" ]; then
-        echo "File is zero size: $DEFAULT_GL_CONF"
+        info "File is zero size: $DEFAULT_GL_CONF"
     elif [ -e "$DEFAULT_GL_CONF" ]; then
-        echo "Exists but is not a file: $DEFAULT_GL_CONF"
-    elif [ -d "$GL_DIR" ]; then
-        echo "$GL_DIR directory exists but does not contain $GL_CONF"
-    elif [ -e "$GL_DIR" ]; then
-        echo "$GL_DIR exists but is not a directory"
-    else
-        echo "Does not exist: $GL_DIR"
+        info "Exists but is not a file: $DEFAULT_GL_CONF"
     fi
-    echo "BASH_SOURCE = ${BASH_SOURCE[*]}"
-    echo "ERROR: Unable to locate gl directory and/or config file $GL_CONF" 1>&2
-    exit 1
+    err_exit "Unable to locate gl config file $GL_CONF"
 fi
 
 REPO_GL_CONF=./$GL_CONF
 if [ -f "$REPO_GL_CONF" ]; then
-    echo "Found repo gl config file: $REPO_GL_CONF"
+    info "Found repo gl config file: $REPO_GL_CONF"
 else
-    echo "No repo-specific gl config file. Default only will be used."
+    info "No repo-specific gl config file. Default only will be used."
     REPO_GL_CONF=""
 fi
 
 FF_SH="file_filter.sh"
 # file_filter script should be in a sibling directory to this one
-FF_DIR="$GL_DIR/../file_filter"
+FF_DIR="${CMS_META_TOOLS_PATH}/file_filter"
 FF_TARGETS="$FF_DIR/$FF_SH"
 if [ -x "$FF_TARGETS" ] && [ -s "$FF_TARGETS" ]; then
-    echo "Located $FF_SH in $FF_DIR"
+    info "Located $FF_SH in $FF_DIR"
 else
     if [ -x "$FF_TARGETS" ]; then
-        echo "File is zero size: $FF_TARGETS"
+        info "File is zero size: $FF_TARGETS"
     elif [ -s "$FF_TARGETS" ]; then
-        echo "File is not executable: $FF_TARGETS"
+        info "File is not executable: $FF_TARGETS"
     elif [ -f "$FF_TARGETS" ]; then
-        echo "File is zero size and not executable: $FF_TARGETS"
+        info "File is zero size and not executable: $FF_TARGETS"
     elif [ -e "$FF_TARGETS" ]; then
-        echo "Exists but is not a file: $FF_TARGETS"
+        info "Exists but is not a file: $FF_TARGETS"
     elif [ -d "$FF_DIR" ]; then
-        echo "Does not exist: $FF_TARGETS"
+        info "Does not exist: $FF_TARGETS"
     elif [ -e "$FF_DIR" ]; then
-        echo "Exists but is not a directory: $FF_DIR"
+        info "Exists but is not a directory: $FF_DIR"
     else
-        echo "Does not exist: $FF_DIR"
+        info "Does not exist: $FF_DIR"
     fi
-    echo "BASH_SOURCE = ${BASH_SOURCE[*]}"
-    echo "ERROR: Problem with $FF_SH in $FF_DIR directory." 1>&2
-    exit 1
+    err_exit "Problem with $FF_SH in $FF_DIR directory"
 fi
 
 if ! git ls-files --empty-directory > $TMPFILE1 ; then
-    echo "ERROR: Command failed:  git ls-files --empty-directory" 1>&2
     rm -f $TMPFILE1 >/dev/null 2>&1
-    exit 1
+    err_exit "Command failed:  git ls-files --empty-directory"
 fi
 
 # $REPO_GL_CONF not in quotes because we know it has no whitespace and because if it is
 # blank (meaning there is no repo gl config file), we do not want it passed as an empty
 # string argument
 if ! cat $TMPFILE1 | "$FF_TARGETS" "$DEFAULT_GL_CONF" $REPO_GL_CONF > $TMPFILE2 ; then
-    echo "ERROR: $FF_TARGETS failed" 1>&2
     rm -f $TMPFILE1 $TMPFILE2 >/dev/null 2>&1
-    exit 1
+    err_exit "$FF_TARGETS failed"
 elif [ ! -s "$TMPFILE2" ]; then
-    echo "No go code found to scan that met the filtering criteria"
+    info "No go code found to scan that met the filtering criteria"
     exit 0
 fi
 
@@ -142,10 +182,9 @@ EOF
 rm -f $TMPFILE1 $TMPFILE2 >/dev/null 2>&1
 
 if [ $FAIL -eq 0 ]; then
-    echo "All scanned code passed"
-else
-    echo "Some code failed gofmt check, see list above" 1>&2
-    echo "To fix detected errors in a file, run: gofmt -s -l -w <filename>" 1>&2
+    info "All scanned code passed"
+    exit 0
 fi
 
-exit $FAIL
+info "To fix detected errors in a file, run: gofmt -s -l -w <filename>"
+err_exit "Some code failed gofmt check, see list above"

--- a/scripts/runLint.sh
+++ b/scripts/runLint.sh
@@ -23,8 +23,71 @@
 # (MIT License)
 
 # Find my directory, so I know where to find my friends
-MYDIR=$(dirname ${BASH_SOURCE[0]})
-CMTROOT=$MYDIR/..
+MYDIR="scripts"
+MYNAME="runLint.sh"
+
+function info
+{
+    echo "$MYNAME: $*"
+}
+
+function error
+{
+    info "ERROR: $*" 1>&2
+}
+
+function err_exit
+{
+    error "$*"
+    exit 1
+}
+
+function run_cmd
+{
+    local rc
+    "$@"
+    rc=$?
+    [ $rc -ne 0 ] && error "Command failed with rc $rc: $*"
+    return $rc
+}
+
+function run_cmd_verify_dir
+{
+    out=$("$@") || err_exit "Command failed: $*"
+    [ -n "$out" ] || err_exit "Command gave blank outut: $*"
+    [ -e "$out" ] || err_exit "Nonexistent path ($out) given by command: $*"
+    [ -d "$out" ] || err_exit "Non-directory path ($out) given by command: $*"
+}
+
+[ -n "${CMS_META_TOOLS_PATH}" ] && info "CMS_META_TOOLS_PATH is set to $CMS_META_TOOLS_PATH"
+
+# If CMS_META_TOOLS_PATH variable is set to a valid value, we will defer to that
+if [ -n "${CMS_META_TOOLS_PATH}" ] && [ -f "${CMS_META_TOOLS_PATH}/${MYDIR}/${MYNAME}" ]; then
+    info "Using value from CMS_META_TOOLS_PATH variable"
+    MYDIR_PATH="${CMS_META_TOOLS_PATH}/${MYDIR}"
+# In this case, let's first try realpath, since it gives us the cleanest paths
+elif realpath / >/dev/null 2>&1 ; then
+    # realpath is available, so let's use that
+    run_cmd_verify_dir dirname "$0"
+    run_cmd_verify_dir realpath "$out"
+    MYDIR_PATH="$out"
+    # Export CMS_META_TOOLS_PATH environment variable so any other scripts we call
+    # can use it, rather than repeating this stuff
+    run_cmd_verify_dir realpath "${MYDIR_PATH}/.."
+    export CMS_META_TOOLS_PATH="$out"
+    info "Exported CMS_META_TOOLS_PATH as '${CMS_META_TOOLS_PATH}'"
+# Backup plan is to use BASH_SOURCE, but note that MacOS in particular does not support this
+elif [ -n "${BASH_SOURCE[0]}" ]; then
+    run_cmd_verify_dir dirname "${BASH_SOURCE[0]}"
+    MYDIR_PATH="$out"
+    # Export CMS_META_TOOLS_PATH environment variable so any other scripts we call
+    # can use it, rather than repeating this stuff
+    export CMS_META_TOOLS_PATH="${MYDIR_PATH}/.."
+    info "Exported CMS_META_TOOLS_PATH as '${CMS_META_TOOLS_PATH}'"
+else
+    info "realpath and BASH_SOURCE both unavailable"
+    err_exit "Unable to determine path to cms-meta-tools"
+fi
 
 # These do not take long to run, and do not depend on each other, so we let
 # them run even if one fails, so the build can report all problems found.
@@ -32,10 +95,15 @@ RC=0
 
 # No config file is needed for this tool. The defaults are fine in many cases,
 # but it should run in every repo.
-$CMTROOT/copyright_license_check/copyright_license_check.sh || RC=1
+run_cmd "${CMS_META_TOOLS_PATH}/copyright_license_check/copyright_license_check.sh" || RC=1
 
 # If there is no go code in the repo, this tool will do nothing and have
 # exit code 0
-$CMTROOT/go_lint/go_lint.sh || RC=1
+run_cmd "${CMS_META_TOOLS_PATH}/go_lint/go_lint.sh" || RC=1
 
-exit $RC
+if [ $RC -eq 0 ]; then
+    info "PASSED"
+    exit 0
+fi
+
+err_exit "One or more failures occurred"


### PR DESCRIPTION
This PR makes no changes to the core logic of any of the cms-meta-tools utilities. Instead, it does two things:

1) Tries to make the shell scripts in cms-meta-tools more consistent with one another, mostly in terms of variable and function names. This just makes it easier to maintain and understand.

2) Modifies the shell scripts so that they work on Macs as well as in our build pipeline. This mainly consists of sidestepping three issues:
a. The implementation of sed on Macs requires you to pass an argument to the -i (inline replace) flag, whereas other implementations forbid it to take an argument. This is avoided by not doing inline replacement, but instead creating a new, modified file, and then copying it over the original file.
b. The implementation of Bash on Macs does not have the BASH_SOURCE environment variable (used to determine the true path to a script being run). This can be avoided by using the realpath command. This command is not installed by default on Macs, but it is not difficult to install, and I haven't found a very good way to address this otherwise.
c. The implementation of grep on Macs doesn't like it if you have an empty subexpression included in a | expression. There is no need to have empty subexpressions, it can just make some expressions shorter to use them. But this issue is easily avoided just by not using them.

I tested this PR in our build pipeline in several repos to verify that it worked. And Mr. David Laine bravely and generously tested it on a couple of repos on his Mac laptop.