### PR TITLE
CASMCMS-7649: Add ability to get latest stable RPM information

### DIFF
--- a/latest_version/latest_version.sh
+++ b/latest_version/latest_version.sh
@@ -27,9 +27,27 @@ usage: latest_version.sh [--major x [--minor y]]
                          [--docker | --helm] [--type <type>]
                          [[--server <server>] [--team <team>]  | [--url <url>]]
                          [--outfile <file> [--overwrite]] image_name
+usage: latest_version.sh [--major x [--minor y]]
+                         --rpm 
+                         [--server <server>] [--type <type>] [--uri <uri>] 
+                         [--outfile <file> [--overwrite]] rpm_name
+usage: latest_version.sh [--major x [--minor y]]
+                         --rpm 
+                         [--url <url>] 
+                         [--outfile <file> [--overwrite]] rpm_name
        latest_version.sh {-h || --help}"
 
 USAGE_EXTRA="\
+Looks in file for newest version of specified image or RPM, and returns the version string.
+If a major is specified, it confines itself to versions of that major number.
+If a minor is also specified, it further confines itself to versions of that minor number.
+Major and minor numbers must be nonnegative integers and may not have leading 0s
+
+Version is written to either the specified outfile or <image_name>.version if no outfile is specified.
+If the output file already exists, the script exits in error unless --overwrite is specified.
+
+For docker/helm:
+
 server: algol60 or arti. Defaults to algol60 (unless url is specified, in which case it is not used)
 team: Defaults to csm (unless url is specified, in which case it is not used)
 type: Defaults to stable (unless url is specified, in which case it may still be specified but has no
@@ -47,15 +65,17 @@ For url, the file at the specified URL will be used.
 docker: Assumes file is in the same JSON format as the arti/algol60 repository.catalog files
 helm: Assumes file is in the same YAML format as the arti/algol60 index.yaml files
 
-Looks in file for newest version of specified image name, and returns the version string.
-If a major is specified, it confines itself to versions of that major number.
-If a minor is also specified, it further confines itself to versions of that minor number.
-Major and minor numbers must be nonnegative integers and may not have leading 0s
 For algol60, the type field is used within these files to distinguish between
 stable and unstable images by looking at the path to the images.
 
-Version is written to either the specified outfile or <image_name>.version if no outfile is specified.
-If the output file already exists, the script exits in error unless --overwrite is specified."
+For RPMs:
+
+server: algol60 or custom URL. Defaults to algol60.
+type: If server is algol60, defaults to stable. If server is custom URL, type is not a valid argument.
+uri: If server is not algol60, this is not a valid argument.
+
+For server algol60, tool looks for RPMs in: https://artifactory.algol60.net/artifactory/csm-rpms/hpe/<type>/<uri>/
+Otherwise it will look for the RPMs at the custom URL that is specified."
 
 MYDIR="latest_version"
 MYNAME="latest_version.sh"
@@ -130,20 +150,58 @@ MAJOR=""
 MINOR=""
 TEAM=""
 TYPE=""
-DOCKER_HELM=""
+DOCKER_HELM_RPM=""
 OUTFILE=""
 OVERWRITE=N
 SERVER=""
 URL=""
+URI=""
+URLFILE=""
+NAMEFILE=""
+ARCH=""
+ARCHSTRIP=""
+
+function check_outputfile
+{
+    local FILE
+    FILE="$1"
+    # If no output file is specified, nothing to check
+    [ -z "$FILE" ] && return 0
+    # If the specified output file does not exist, we're good
+    [ -e "$FILE" ] || return 0
+    # If the specified output file exists and is not a regular file, that is bad
+    [ -f "$FILE" ] || usage "Output file $FILE already exists and is not a regular file"
+    # Finally, since the file exists, make sure overwrite is set
+    [ "$OVERWRITE" = Y ] && info "$FILE already exists and will be overwritten (--overwrite specified)" && return 0
+    usage "Output file $FILE already exists, and --overwrite not specified"
+}
 
 function parse_arguments
 {
+    local FILE
+
     while [ $# -gt 0 ]; do
         case "$1" in
-            "--docker"|"--helm")
-                [ -n "$DOCKER_HELM" ] && usage "--docker and --helm must be specified no more than once total"
-                DOCKER_HELM=$(echo "$1" | sed 's/^[-][-]//')
+            "--docker"|"--helm"|"--rpm")
+                [ -n "$DOCKER_HELM_RPM" ] && usage "--docker/--helm/--rpm must be specified no more than once total"
+                DOCKER_HELM_RPM=$(echo "$1" | sed 's/^[-][-]//')
                 shift
+                ;;
+            "--arch")
+                [ -n "$ARCH" ] && usage "--arch may not be specified multiple times"
+                [ $# -lt 2 ] && usage "--arch requires an argument"
+                [ -z "$2" ] && usage "Arch may not be blank"
+                echo "$2" | grep -Eq "[^-_.a-zA-Z0-9]" && usage "Invalid characters in arch: $2"
+                ARCH="$2"
+                shift 2
+                ;;
+            "--archstrip")
+                [ -n "$ARCHSTRIP" ] && usage "--archstrip may not be specified multiple times"
+                [ $# -lt 2 ] && usage "--archstrip requires an argument"
+                [ -z "$2" ] && usage "Archstrip argument may not be blank"
+                echo "$2" | grep -Eiq "^(true|false)$" && usage "--archstrip must be true or false. Invalid archstrip argument: $2"
+                ARCHSTRIP="$(echo $2 | tr 'A-Z' 'a-z')"
+                shift 2
                 ;;
             "--major")
                 [ -n "$MAJOR" ] && usage "--major may not be specified multiple times"
@@ -159,11 +217,17 @@ function parse_arguments
                 MINOR="$2"
                 shift 2
                 ;;
+            "--namefile")
+                [ -n "$NAMEFILE" ] && usage "--namefile may not be specified multiple times"
+                [ $# -lt 2 ] && usage "--namefile requires an argument"
+                [ -z "$2" ] && usage "Output RPM name file may not be blank"
+                NAMEFILE="$2"
+                shift 2
+                ;;
             "--outfile")
                 [ -n "$OUTFILE" ] && usage "--outfile may not be specified multiple times"
                 [ $# -lt 2 ] && usage "--outfile requires an argument"
                 [ -z "$2" ] && usage "Output file may not be blank"
-                [ -e "$2" ] && [ ! -f "$2" ] && usage "Output file already exists and is not a regular file: $2"
                 OUTFILE="$2"
                 shift 2
                 ;;
@@ -174,18 +238,13 @@ function parse_arguments
                 ;;
             "--server")
                 [ -n "$SERVER" ] && usage "--server may not be specified multiple times"
-                [ -n "$URL" ] && usage "--server and --url are mutually exclusive"
                 [ $# -lt 2 ] && usage "--server requires an argument"
                 [ -z "$2" ] && usage "Server may not be blank"
-                if [ "$2" != "arti" ] && [ "$2" != "algol60" ]; then
-                    usage "--server argument must be arti or algol60. Invalid server: $2"
-                fi
                 SERVER="$2"
                 shift 2
                 ;;
             "--team")
                 [ -n "$TEAM" ] && usage "--team may not be specified multiple times"
-                [ -n "$URL" ] && usage "--team and --url are mutually exclusive"
                 [ $# -lt 2 ] && usage "--team requires an argument"
                 [ -z "$2" ] && usage "Team may not be blank"
                 echo "$2" | grep -Eq "[^-_.a-zA-Z0-9]" && usage "Invalid characters in team name: $2"
@@ -200,51 +259,88 @@ function parse_arguments
                 TYPE="$2"
                 shift 2
                 ;;
+            "--uri")
+                [ -n "$URI" ] && usage "--uri may not be specified multiple times"
+                [ $# -lt 2 ] && usage "--uri requires an argument"
+                [ -z "$2" ] && usage "URI may not be blank"
+                URI="$2"
+                shift 2
+                ;;
             "--url")
                 [ -n "$URL" ] && usage "--url may not be specified multiple times"
-                [ -n "$SERVER" ] && usage "--server and --url are mutually exclusive"
-                [ -n "$TEAM" ] && usage "--team and --url are mutually exclusive"
                 [ $# -lt 2 ] && usage "--url requires an argument"
                 [ -z "$2" ] && usage "URL may not be blank"
                 URL="$2"
                 shift 2
                 ;;
+            "--urlfile")
+                [ -n "$URLFILE" ] && usage "--urlfile may not be specified multiple times"
+                [ $# -lt 2 ] && usage "--urlfile requires an argument"
+                [ -z "$2" ] && usage "Output RPM url file may not be blank"
+                URLFILE="$2"
+                shift 2
+                ;;
             *)
                 # Must be our image name
-                [ -z "$1" ] && usage "Image name may not be blank"
-                echo "$1" | grep -Eq "[^-_.a-zA-Z0-9]" && usage "Invalid characters in image name: $1"
+                [ -z "$1" ] && usage "Image/RPM name may not be blank"
+                echo "$1" | grep -Eq "[^-_.a-zA-Z0-9]" && usage "Invalid characters in image/RPM name: $1"
                 IMAGE_NAME="$1"
                 shift
                 [ $# -eq 0 ] || usage "Extra arguments found beyond image name: $*"
                 ;;
         esac
     done
-    [ -z "$IMAGE_NAME" ] && usage "Image name must be specified"
-    [ -z "$DOCKER_HELM" ] && DOCKER_HELM="docker"
-    [ -n "$MINOR" ] && [ -z "$MAJOR" ] && usage "--minor may not be specified without --major"
+    [ -n "$SERVER" ] && [ -n "$URL" ] && usage "--server and --url are mutually exclusive"
+    [ -z "$IMAGE_NAME" ] && 
+        usage "Image name must be specified"
+    [ -z "$DOCKER_HELM_RPM" ] && DOCKER_HELM_RPM="docker"
+    [ -n "$MINOR" ] && [ -z "$MAJOR" ] && 
+        usage "--minor may not be specified without --major"
     [ -z "$OUTFILE" ] && OUTFILE="${IMAGE_NAME}.version"
-    if [ -e "$OUTFILE" ]; then
-        if [ ! -f "$OUTFILE" ]; then
-            usage "Output file $OUTFILE already exists but is not a regular file"
-        elif [ "$OVERWRITE" = Y ]; then
-            echo "$OUTFILE already exists and will be overwritten (--overwrite specified)" 1>&2
-        else
-            usage "Output file $OUTFILE already exists, and --overwrite not specified"
-        fi
-    fi
-    # If URL is not specified, then set default values for TEAM, TYPE, and SERVER
+    check_outputfile "$OUTFILE"
     if [ -z "$URL" ]; then
-        [ -z "$TEAM" ] && TEAM="csm"
         [ -z "$TYPE" ] && TYPE="stable"
         [ -z "$SERVER" ] && SERVER="algol60"
     fi
+    case "$DOCKER_HELM_RPM" in
+        "docker"|"helm")
+            [ -n "$TEAM" ] && [ -n "$URL" ] && usage "--team and --url are mutually exclusive"
+            [ -n "$NAMEFILE" ] && usage "--namefile is not valid with $DOCKER_HELM_RPM"
+            [ -n "$ARCH" ] && usage "--arch is not valid with $DOCKER_HELM_RPM"
+            [ -n "$ARCHSTRIP" ] && usage "--archstrip is not valid with $DOCKER_HELM_RPM"
+            [ -n "$URI" ] && usage "--uri is not valid with $DOCKER_HELM_RPM"
+            [ -n "$URLFILE" ] && usage "--urlfile is not valid with $DOCKER_HELM_RPM"
+            [ "$SERVER" != "arti" ] && [ "$SERVER" != "algol60" ] &&
+                usage "For docker and helm, --server argument must be arti or algol60. Invalid server: $2"
+            # If URL is not specified, then set default values for TEAM, TYPE, and SERVER
+            if [ -z "$URL" ]; then
+                [ -z "$TEAM" ] && TEAM="csm"
+                [ -z "$TYPE" ] && TYPE="stable"
+                [ -z "$SERVER" ] && SERVER="algol60"
+            fi
+            ;;
+        "rpm")
+            [ "$ARCHSTRIP" = false ] && [ -n "$ARCH" ] && usage "If --archstrip is false, --arch may not be used"
+            [ -z "$ARCHSTRIP" ] && ARCHSTRIP=true
+            [ -n "$URI" ] && [ -n "$URL" ] && usage "--uri and --url are mutually exclusive"
+            [ -n "$TEAM" ] && usage "--team is not valid with --rpm"
+            [ -n "$SERVER" ] && [ "$SERVER" != algol60 ] && 
+                usage "For rpm, if --server is specified, its argument must be algol60"
+            [ -n "$URL" ] && [ -n "$TYPE" ] && 
+                usage "For rpm, --url and --type are mutually exclusive"
+            check_outputfile "$NAMEFILE"
+            check_outputfile "$URLFILE"
+            ;;
+    esac
 }
 
 parse_arguments "$@"
 if [ -z "$URL" ]; then
-    if [ "$SERVER" = "arti" ]; then
-        URL="https://arti.dev.cray.com/artifactory/${TEAM}-${DOCKER_HELM}-${TYPE}-local"
-        if [ "${DOCKER_HELM}" = helm ]; then
+    if [ "${DOCKER_HELM_RPM}" = rpm ]; then
+        URL="https://artifactory.algol60.net/artifactory/csm-rpms/hpe/${TYPE}/${URI}/"
+    elif [ "$SERVER" = "arti" ]; then
+        URL="https://arti.dev.cray.com/artifactory/${TEAM}-${DOCKER_HELM_RPM}-${TYPE}-local"
+        if [ "${DOCKER_HELM_RPM}" = helm ]; then
             URL="$URL/index.yaml"
         else
             URL="$URL/repository.catalog"
@@ -252,18 +348,22 @@ if [ -z "$URL" ]; then
     else
         # algol60
         URL="https://artifactory.algol60.net/artifactory/${TEAM}-"
-        if [ "${DOCKER_HELM}" = helm ]; then
+        if [ "${DOCKER_HELM_RPM}" = helm ]; then
             URL="${URL}helm-charts/index.yaml"
         else
             URL="${URL}docker/repository.catalog"
         fi
     fi
 fi
+# Remove redundant // from URL
+URL=$(echo "$URL" | sed 's#\([^:/]\)///*#\1/#g')
 
-if [ "${DOCKER_HELM}" = helm ]; then
+if [ "${DOCKER_HELM_RPM}" = helm ]; then
     # Test to see if yaml module is available
     . "${CMS_META_TOOLS_PATH}/utils/pyyaml.sh"
     TMPFILE="/tmp/.latest_version.sh.$$.$RANDOM.index.yaml"
+elif [ "${DOCKER_HELM_RPM}" = rpm ]; then
+    TMPFILE="/tmp/.latest_version.sh.$$.$RANDOM.rpms.txt"
 else
     TMPFILE="/tmp/.latest_version.sh.$$.$RANDOM.repository.catalog.json"
 fi
@@ -277,11 +377,6 @@ fi
 # Construct our list of optional arguments to latest_version.py
 OPTIONAL_ARGS=""
 
-# Even if it is set, we do not pass in the type argument if we are
-# using arti, because for arti the type is baked into the URL itself
-if [ -n "$TYPE" ] && [ "$SERVER" != "arti" ]; then
-    OPTIONAL_ARGS="${OPTIONAL_ARGS} --type $TYPE"
-fi
 if [ -n "$MAJOR" ]; then
     OPTIONAL_ARGS="${OPTIONAL_ARGS} --major $MAJOR"
     if [ -n "$MINOR" ]; then
@@ -289,8 +384,100 @@ if [ -n "$MAJOR" ]; then
     fi
 fi
 
+if [ "${DOCKER_HELM_RPM}" = rpm ]; then
+    # If archstrip is true and arch is not set, set arch to the final directory in the URL
+    [ "$ARCHSTRIP" = true ] && [ -z "$ARCH" ] && ARCH=$(echo "$URL" | sed 's#//*$##' | awk -F/ '{ print $NF }') && info "arch defaulting to $ARCH"
+
+    if [ -n "$NAMEFILE" ]; then
+        OPTIONAL_ARGS="${OPTIONAL_ARGS} --rpm-name-outfile $NAMEFILE"
+    elif [ -n "$URLFILE" ]; then
+        # The Python tool only knows names, not URLs, so we have to get a name from it and build the URL ourselves
+        OPTIONAL_ARGS="${OPTIONAL_ARGS} --rpm-name-outfile $URLFILE"
+    fi
+
+    # For RPMs, we do some pre-processing of our input file to filter for our desired RPMs
+    # Our desired file format is <semver> <rpm filename>
+
+    # Version must be legal SemVer 2.0 pattern (see semver.org)
+
+    # For all of these below specifications, note that a 0 by itself is not considered to be a leading 0
+    NUM_PATTERN="0|[1-9][0-9]*"
+
+    # The basic pattern is 3 nonnegative integers without leading 0s, separated by dots
+    BASE_VPATTERN="(${NUM_PATTERN})[.](${NUM_PATTERN})[.](${NUM_PATTERN})"
+
+    # A pre-release identifier is any of the following:
+    # - Any string of 1 or more digits with no leading 0s
+    # - Any string consisting of 1 or more alphanumeric characters or hyphens, with at least 1 non-numeric character
+    PID_PATTERN="(${NUM_PATTERN}|[-a-zA-Z0-9]*[-a-zA-Z][-a-zA-Z0-9]*)"
+
+    # A pre-release version is one or more dot-separated pre-release identifiers
+    PRV_PATTERN="${PID_PATTERN}([.]${PID_PATTERN})*"
+
+    # A build identifier is any of the following:
+    # - Any string consisting of 1 or more alphanumeric characters or hyphens
+    BID_PATTERN="[-a-zA-Z0-9][-a-zA-Z0-9]*"
+
+    # Build metadata is one or more dot-separated build identifiers
+    BMD_PATTERN="${BID_PATTERN}([.]${BID_PATTERN})*"
+
+    # The full version string must begin with the base pattern
+    # After that is an optional hyphen and pre-release version
+    # After those is an optional plus and build-metadata
+    VPATTERN="${BASE_VPATTERN}(-${PRV_PATTERN})?([+]${BMD_PATTERN})?"
+
+    # Grab all href targets beginning with <image name>-<semver> ending with .rpm" or .<arch>.rpm"
+    # Filter out the href=""
+    # Sort and remove any duplicates
+    # Then perform sed magic to get our desired file format
+    RPM_PREFIX_PATTERN="${IMAGE_NAME}-${VPATTERN}"
+    RPM_PATTERN="[hH][rR][eE][fF]=[\"]${RPM_PREFIX_PATTERN}[^\"]*"
+    [ "$ARCHSTRIP" = true ] && RPM_PATTERN="${RPM_PATTERN}[.]${ARCH}"
+    RPM_PATTERN="${RPM_PATTERN}[.]rpm[\"]"
+    RPMFILES=$(grep -Eo "${RPM_PATTERN}" "$TMPFILE" | cut -d\" -f2 | sort -u)
+
+    for RPMFILE in ${RPMFILES}; do
+        # Strip off .rpm
+        TMPNAME=$(echo "$RPMFILE" | sed 's/[.]rpm$//')
+        # If archstrip is true, strip off .arch
+        [ "$ARCHSTRIP" = true ] && TMPNAME=$(echo "$TMPNAME" | sed "s/[.]${ARCH}$//")
+        # Now grep for image_name-semver, then chop off the image_name- prefix
+        SEMVER=$(echo "$TMPNAME" | grep -Eo "^${RPM_PREFIX_PATTERN}" | sed "s/^${IMAGE_NAME}-//")
+        echo "${SEMVER} ${RPMFILE}"
+    done > "$TMPFILE"
+
+else
+
+    # Even if it is set, we do not pass in the type argument if we are
+    # using arti, because for arti the type is baked into the URL itself.
+    # Same for RPMs
+    [ -n "$TYPE" ] && [ "$SERVER" != "arti" ] && 
+        OPTIONAL_ARGS="${OPTIONAL_ARGS} --type $TYPE"
+fi
+
 # Now call latest_version.py located in this directory
-UEV=$("$MYDIR_PATH/latest_version.py" "--${DOCKER_HELM}" --file "$TMPFILE" --image "${IMAGE_NAME}" ${OPTIONAL_ARGS}) || exit 1
+UEV=$("$MYDIR_PATH/latest_version.py" "--${DOCKER_HELM_RPM}" --file "$TMPFILE" --image "${IMAGE_NAME}" ${OPTIONAL_ARGS})
+rc=$?
+rm -f "$TMPFILE" >/dev/null 2>&1
+[ $rc -ne 0 ] && exit 1
+
 info "Found version ${UEV} of ${IMAGE_NAME}"
-echo "$UEV" > $OUTFILE && exit 0
-err_exit "Error writing to $OUTFILE"
+echo "$UEV" > $OUTFILE || err_exit "Error writing to $OUTFILE"
+if [ "${DOCKER_HELM_RPM}" = rpm ]; then
+    if [ -n "$NAMEFILE" ]; then
+        RPMNAME=$(cat $NAMEFILE) || err_exit "Error reading from $NAMEFILE"
+        info "RPM filename is $RPMNAME"
+    elif [ -n "$URLFILE" ]; then
+        RPMNAME=$(cat $URLFILE) || err_exit "Error reading from $URLFILE"
+    fi
+
+    if [ -n "$URLFILE" ]; then
+        # Preprend our URL to it, and write it to URLFILE
+        RPMURL="${URL}/${RPMNAME}"
+        # Remove redundant // from RPMURL
+        RPMURL=$(echo "$RPMURL" | sed 's#\([^:/]\)///*#\1/#g')
+        info "RPM URL is $RPMURL"
+        echo "${RPMURL}" > $URLFILE || err_exit "Error writing to $URLFILE"
+    fi
+fi
+exit 0

--- a/latest_version/update_external_versions.conf.template
+++ b/latest_version/update_external_versions.conf.template
@@ -3,7 +3,11 @@
 # to the latest_versions tool. So in case of conflicting information, the defaults described
 # in that tool are the ones you should follow.
 
-# This file contains any number of stanzas of the following form:
+# This file contains any number of stanzas of the following forms:
+
+#########################################
+# Form 1: Docker images and helm charts
+#########################################
 #
 #image: image_name
 #    major: major number
@@ -78,6 +82,60 @@
 # in the file paths (like on arti.dev), the type parameter should be omitted entirely, otherwise
 # no images will be found.
 
+#########################################
+# Form 2: RPMs
+#########################################
+
+#rpm:  RPM_name
+#    major: major number
+#    minor: minor number
+#    outfile: target filename for version
+#    namefile: target filename for RPM filename
+#    urlfile: target filename for full URL to RPM
+#    server: algol60
+#    type: build type
+#    uri: algol60 URI
+#    url: custom URL
+#    archstrip: true or false
+#    arch: RPM arch
+#
+# For each such stanza, the only required field is the rpm field. This field
+# determines the name of the image whose latest version we wish to discover.
+#
+# The major and minor fields, if present, must contain nonnegative integers.
+# If specified, they constrain the RPM version search to versions with the
+# specified major and (if specified) minor number. If neither is specified, the
+# overall latest version of the RPM will be sought.
+#
+# If archstrip is true, then we filter for RPM filenames that end with
+# .<arch>.rpm (e.g. .x86_64.rpm, .src.rpm, .noarch.rpm, etc), and that
+# part of the filename will not be considered to be part of the version.
+# archstrip defaults to true.
+#
+# arch specifies the architecture of the RPM, for the purposes of the archstrip
+# field. If archstrip is false, this field may not be set. If archstrip is true,
+# this field defaults to the name of the directory that contains the RPM in
+# its URL path.
+#
+# outfile defines the name of the file that the version will be written to.
+# If not specified, it defaults to <RPM_name>.version
+#
+# If namefile is specified, the filename of the RPM with this version will be 
+# written to it. If unspecified, no such file is written.
+#
+# If urlfile is specified, the full URL to the RPM with this version will be
+# written to it. If unspecified, no such file is written.
+#
+# If server is not specified and url is not specified, server defaults to algol60.
+# The url field is mutually exclusive the with server, type, and uri fields.
+#
+# If the url field is specified:
+#    * That custom URL is where the tool will look for RPM files
+#
+# If the server is algol60, then:
+#    * If type is not specified, it defaults to stable
+#    * The tool will look for the RPM files in https://artifactory.algol60.net/artifactory/csm-rpms/hpe/<type>/<uri>/
+
 image: my_image_name
     major: 1
     minor: 7
@@ -94,3 +152,9 @@ image: another_image_name
 image: yet_another_image_name
     major: 1
     url: https://myserver.mil/helm/index.yaml
+
+rpm: cfs-state-reporter
+    major: 1
+    minor: 7
+    uri: sle-15sp3/cfs-state-reporter/x86_64
+    urlfile: cfs-state-reporter-rpm.url

--- a/update_versions/update_versions.conf.template
+++ b/update_versions/update_versions.conf.template
@@ -1,7 +1,13 @@
 #tag: version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
 #sourcefile: file to obtain the actual version from (optional -- if unspecified, .version is assumed)
 #            If this file is executable, it will be executed and the output will be used as the version string.
-#            Otherwise it will be read and its contents will be used as the version string.
+#            Otherwise it will be read and its contents will be used as the version string. The string is checked
+#            to verify it is valid semver (see update_versions.sh header for details)
+#
+#sourcefile_nosemver: Same as sourcefile except that the string it contains is not checked to make sure
+#                     it is valid semver. Instead, it simply must consist of legal characters:
+#                     a-z A-Z 0-9 . , - _ : ; = + / (space) & @ ! $ % * ( ) | { } [ ] < > ? #
+#
 #targetfile: file in which to have version tags replaced. When this line is reached, the replacement
 #            action is performed on this file.
 #


### PR DESCRIPTION
### SUMMARY
[CASMCMS-7645](https://connect.us.cray.com/jira/browse/CASMCMS-7645) was hit because the ansible-execution-environment build for csm-1.0 was using the wrong version of the csm-ssh-key RPM. It was grabbing the overall latest stable RPM, rather than the latest csm-1.0 stable RPM. This is exactly the problem that the update_external_versions tool was created to solve, but that tool only supports docker images and helm charts.

**UNTIL NOW**

### TL;DR
 Add support for RPMs to update_external_versions and update_versions.

### TESTING
I regression tested a few repo builds to make sure that these changes did not break any existing functionality. I also made a development branch for ansible-execution-environment where I implemented the CASMCMS-7645 fix using the options added by this PR, and verified that it worked as expected.

### NEXT STEPS
Once this PR is merged, I will make PRs for the repos which install external RPMs where we would like to pin their major and minor numbers.

### GORY DETAILS
This PR adds support for RPMs to update_external_versions (and its underlying tool, latest_version). Things are a little messier with RPMs than with docker images and helm charts, because there is no pre-created index file with the listing of available RPMs (like there is for docker and helm). Additionally, when installing RPMs in our builds, it is often more useful to know the URL to the RPM file than simply to know its version. Because of this, adding support for RPMs involved a slightly different set of fields in the update_external_versions.conf file, and also involved the ability to report not just the RPM version, but also its base filename and its full URL.

For docker and helm, usually the files created by update_external_versions are consumed by the update_versions tool (in order to replace placeholder strings with version numbers, at build time). Since this has been used for version numbers, the tool verifies that the version string is a legal version number. However, that checking would break the ability to use this tool to substitute in RPM URLs or filenames.

Accordingly, the second change made by this PR is to add the option in update_versions to specify source files whose contents are subject to a much laxer validation -- namely, it just verifies that they only contain alphanumeric characters, and some punctuation, The reason it still does any validation is mainly a convenience, so that we know it won't be trying to use strings that would break the sed command used to do the replacement.
