### PR TITLE
CASMCMS-7662: Create helper script to apply zypper patches

### DIFF
--- a/cms-meta-tools.spec
+++ b/cms-meta-tools.spec
@@ -92,7 +92,8 @@ install -m 755 -d                                                   %{buildroot}
 install -m 755 update_versions/update_versions.sh                   %{buildroot}%{uvdir}
 
 install -m 755 -d                                                   %{buildroot}%{utdir}/
-install -m 644 utils/pyyaml.sh		                                %{buildroot}%{utdir}
+install -m 644 utils/pyyaml.sh                                      %{buildroot}%{utdir}
+install -m 755 utils/zypper-patch.sh                                %{buildroot}%{utdir}
 
 %clean
 rm -f %{buildroot}%{clcdir}/copyright_license_check.sh
@@ -120,6 +121,7 @@ rm -f %{buildroot}%{scdir}/runLint.sh
 rmdir %{buildroot}%{scdir}
 
 rm -f %{buildroot}%{utdir}/pyyaml.sh
+rm -f %{buildroot}%{utdir}/zypper-patch.sh
 rmdir %{buildroot}%{utdir}
 
 rm -f %{buildroot}%{uvdir}/update_versions.sh
@@ -162,5 +164,6 @@ rmdir %{buildroot}%{cmtdir}
 
 %dir %{uvdir}
 %attr(644, root, root) %{utdir}/pyyaml.sh
+%attr(755, root, root) %{utdir}/zypper-patch.sh
 
 %changelog

--- a/utils/zypper-patch.sh
+++ b/utils/zypper-patch.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+# This script is intended to be copied into a Docker image and run,
+# in order to apply necessary patches (typically security patches).
+# Ideally it should come after all other zypper commands and RPM
+# installs (to avoid the case where you zypper install something later
+# and fail to apply security patches for it or its dependencies that
+# get pulled in).
+
+# Run with set -x to help with debugging
+set -x
+
+# Do a zypper refresh without -f, so we only refresh repos if needed
+zypper --non-interactive refresh
+
+# Apply necessary patches in a while loop. This is done because
+# the zypper patch command returns 103 when it has successfully applied
+# a patch to itself, but it needs to be re-run in order to apply the remaining
+# patches. 
+
+# I do not know if this is guaranteed to only happen a single time per execution,
+# so in the case of 103 return codes, we will retry up to 10 times before
+# failing.
+
+count=0
+while [ $count -lt 10 ]; do
+    zypper --non-interactive patch
+    rc=$?
+
+    # If rc = 0, break out of the while loop
+    [ $rc -eq 0 ] && break
+
+    # If rc != 103, then this is a true failure
+    [ $rc -ne 103 ] && exit $rc
+
+    # If rc = 103, increment count and retry
+    let count+=1
+done
+
+# If count = 10, that means the zypper command never gave return code 0
+[ $count -eq 10 ] && exit 103
+
+# Finally, clean up package caches and metadata
+zypper --non-interactive clean -a
+exit $?


### PR DESCRIPTION
This PR was spawned because of a discussion in a recent PR review:
https://github.com/Cray-HPE/console-node/pull/23#discussion_r737918974

We run the "zypper patch" command in several Dockerfiles in order to apply the latest security patches when building the docker images. In this way, we usually avoid Snyk scan failures. However, our current Dockerfiles do not handle the case where the "zypper patch" command exits with 103 return code.

That return code is not a failure. It means that the zypper command has had to patch itself, and needs to be run again in order to apply the remaining patches. 

It is not difficult to add logic to our Dockerfiles to handle this case, but it is ugly. And it is inconvenient to have to go and update all of our Dockerfiles any time we need to modify how we are applying our zypper patches.

This PR creates a simple shell script which does the zypper patch steps. We already clone cms-meta-tools as part of our build process, so it's a simple matter to have our Dockerfiles copy this script, run it, and then delete it. That makes the Dockerfiles much cleaner and also makes maintaining this much easier.

I created a dev branch of one of our repos (ansible-execution-environment) and verified that the above changes to its Dockerfile achieved the desired results.