### PR TITLE
Pull in latest commits from master to release/cmt-2.0 branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+## Summary and Scope
+
+_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
+
+_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
+
+## Issues and Related PRs
+
+_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._
+
+* Resolves [issue id](issue link)
+* Change will also be needed in `<insert branch name here>`
+* Future work required by [issue id](issue link)
+* Documentation changes required in [issue id](issue link)
+* Merge with/before/after `<insert PR URL here>`
+
+## Testing
+
+_List the environments in which these changes were tested._
+
+### Tested on:
+
+  * `<development system>`
+  * Local development environment
+  * Virtual Shasta
+
+### Test description:
+
+_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
+
+- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
+- Were continuous integration tests run? If not, why?
+- Was upgrade tested? If not, why?
+- Was downgrade tested? If not, why?
+- Were new tests (or test issues/Jiras) created for this change?
+
+## Risks and Mitigations
+
+_Are there known issues with these changes? Any other special considerations?_
+
+
+## Pull Request Checklist
+
+- [ ] Version number(s) incremented, if applicable
+- [ ] Copyrights updated
+- [ ] License file intact
+- [ ] Target branch correct
+- [ ] CHANGELOG.md updated
+- [ ] Testing is appropriate and complete, if applicable
+- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
+

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ prepare:
 		cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
 
 rpm_package_source:
-		tar --transform 'flags=r;s,^,/$(SOURCE_NAME)/,' --exclude .git --exclude dist -cvjf $(SOURCE_PATH) .
+		tar --transform 'flags=r;s,^,/$(SOURCE_NAME)/,' --exclude .git --exclude dist --exclude pymods -cvjf $(SOURCE_PATH) .
 
 rpm_build_source:
 		BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"

--- a/cms-meta-tools.spec
+++ b/cms-meta-tools.spec
@@ -48,6 +48,7 @@ Prefix: /opt/cray/cms-meta-tools
 %define gidir %{cmtdir}/git_info
 %define gldir %{cmtdir}/go_lint
 %define lvdir %{cmtdir}/latest_version
+%define uadir %{cmtdir}/update_appversion
 %define uvdir %{cmtdir}/update_versions
 %define scdir %{cmtdir}/scripts
 %define utdir %{cmtdir}/utils
@@ -87,6 +88,10 @@ install -m 755 latest_version/update_external_versions.sh           %{buildroot}
 install -m 755 -d                                                   %{buildroot}%{scdir}/
 install -m 755 scripts/runBuildPrep.sh                              %{buildroot}%{scdir}
 install -m 755 scripts/runLint.sh                                   %{buildroot}%{scdir}
+install -m 755 scripts/update-chart-app-version.sh                  %{buildroot}%{scdir}
+
+install -m 755 -d                                                   %{buildroot}%{uadir}/
+install -m 755 update_appversion/update_appversion.py               %{buildroot}%{uadir}
 
 install -m 755 -d                                                   %{buildroot}%{uvdir}/
 install -m 755 update_versions/update_versions.sh                   %{buildroot}%{uvdir}
@@ -117,10 +122,14 @@ rmdir %{buildroot}%{lvdir}
 
 rm -f %{buildroot}%{scdir}/runBuildPrep.sh
 rm -f %{buildroot}%{scdir}/runLint.sh
+rm -f %{buildroot}%{scdir}/update-chart-app-version.sh
 rmdir %{buildroot}%{scdir}
 
 rm -f %{buildroot}%{utdir}/pyyaml.sh
 rmdir %{buildroot}%{utdir}
+
+rm -f %{buildroot}%{uadir}/update_appversion.py
+rmdir %{buildroot}%{uadir}
 
 rm -f %{buildroot}%{uvdir}/update_versions.sh
 rmdir %{buildroot}%{uvdir}
@@ -156,6 +165,10 @@ rmdir %{buildroot}%{cmtdir}
 %dir %{scdir}
 %attr(755, root, root) %{scdir}/runBuildPrep.sh
 %attr(755, root, root) %{scdir}/runLint.sh
+%attr(755, root, root) %{scdir}/update-chart-app-version.sh
+
+%dir %{uadir}
+%attr(755, root, root) %{uadir}/update_appversion.py
 
 %dir %{uvdir}
 %attr(755, root, root) %{uvdir}/update_versions.sh

--- a/git_info/git_info.sh
+++ b/git_info/git_info.sh
@@ -147,8 +147,9 @@ while read vars; do
             echo "annotations:" >> "${target}" ||
                 err_exit "Error appending to ${target}"
         fi
-        sed -e "s,^annotations:\s*$,annotations:\n  git/branch: \"${GIT_BRANCH}\"\n  git/commit-date: \"${GIT_COMMIT_DATE}\"\n  git/commit-id: \"${GIT_COMMIT_ID}\"," -i "${target}" ||
+        sed -e "s,^annotations:\s*$,annotations:\n  git/branch: \"${GIT_BRANCH}\"\n  git/commit-date: \"${GIT_COMMIT_DATE}\"\n  git/commit-id: \"${GIT_COMMIT_ID}\"," ${target} > ${target}.tmp ||
             err_exit "Error appending to ${target}"
+        mv ${target}.tmp ${target}
         diff "$target" "$TMPFILE" && 
             err_exit "Append seemed to work but $target is unchanged"
         rm -f "$TMPFILE"

--- a/git_info/git_info.sh
+++ b/git_info/git_info.sh
@@ -67,8 +67,8 @@ function sed_diff_replace
         err_exit "sed command failed or error writing to $tmpfile"
     diff "$target" "$tmpfile" && 
         err_exit "sed command ran but no changes were made"
-    run_cmd cp "$tmpfile" "$target"
-    rm -f "$tmpfile"
+    run_cmd cp -v "$tmpfile" "$target"
+    rm -fv "$tmpfile"
     return 0
 }
 
@@ -87,7 +87,7 @@ while [ -e "$TMPFILE" ]; do
 done
 run_cmd git log -n 1 --pretty=tformat:"%H %cI %cd" --date=format:"%a %b %d %Y" > "$TMPFILE"
 read -r GIT_COMMIT_ID GIT_COMMIT_DATE GIT_COMMIT_CHANGELOG_DATE <<< $(head -1 "$TMPFILE")
-rm -f "$TMPFILE"
+rm -fv "$TMPFILE"
 echo "git branch: ${GIT_BRANCH}" > "${GITINFO_OUTFILE}" ||
     err_exit "Unable to write to ${GITINFO_OUTFILE}"
 run_cmd git log --decorate=full --source -n 1 >> "${GITINFO_OUTFILE}"
@@ -141,18 +141,18 @@ while read vars; do
     fi
     if [ "$type" = chart ]; then
         # Make copy of original file, for comparison
-        run_cmd cp "$target" "$TMPFILE"
+        run_cmd cp -v "$target" "$TMPFILE"
         info "Appending git metadata to ${target}"
         if ! grep -Eq '^annotations:[[:space:]]*$' "${target}"; then
             echo "annotations:" >> "${target}" ||
                 err_exit "Error appending to ${target}"
         fi
-        sed -e "s,^annotations:\s*$,annotations:\n  git/branch: \"${GIT_BRANCH}\"\n  git/commit-date: \"${GIT_COMMIT_DATE}\"\n  git/commit-id: \"${GIT_COMMIT_ID}\"," ${target} > ${target}.tmp ||
+        sed -e "s,^annotations:\s*$,annotations:\n  git/branch: \"${GIT_BRANCH}\"\n  git/commit-date: \"${GIT_COMMIT_DATE}\"\n  git/commit-id: \"${GIT_COMMIT_ID}\"," "${target}" > "${target}.tmp" ||
             err_exit "Error appending to ${target}"
-        mv ${target}.tmp ${target}
+        run_cmd mv "${target}.tmp" "${target}"
         diff "$target" "$TMPFILE" && 
             err_exit "Append seemed to work but $target is unchanged"
-        rm -f "$TMPFILE"
+        rm -fv "$TMPFILE"
     elif [ "$type" = dockerfile ]; then
         [ -n "$clist" ] || 
             err_exit "No container names specified for dockerfile $target"
@@ -178,9 +178,9 @@ done <<-EOF
 $(grep -E '^(chart|dockerfile|specfile):' "${GITINFO_CONFIG}")
 EOF
 
-[ -f "$TMPFILE" ] && rm -f "$TMPFILE"
-[ -f "$CHANGELOG" ] && rm -f "$CHANGELOG"
-[ -f "$DOCKERCOPY" ] && rm -f "$DOCKERCOPY"
+[ -f "$TMPFILE" ] && rm -fv "$TMPFILE"
+[ -f "$CHANGELOG" ] && rm -fv "$CHANGELOG"
+[ -f "$DOCKERCOPY" ] && rm -fv "$DOCKERCOPY"
 
 info "SUCCESS"
 exit 0

--- a/latest_version/latest_version.py
+++ b/latest_version/latest_version.py
@@ -179,10 +179,16 @@ def compare_identifiers(a, b):
         return 0
 
 def remove_build(s):
+    # The build metadata string may be separated using either an underscore or a plus
     try:
         return s[:s.index('+')]
     except ValueError:
-        return s
+        # No + was found. Try _
+        try:
+            return s[:s.index('_')]
+        except ValueError:
+            # This means there was no build metadata to remove
+            return s
 
 def get_version_and_prerelease(s):
     try:

--- a/scripts/update-chart-app-version.sh
+++ b/scripts/update-chart-app-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+CHART_PATH="$1"
+APP_VERSION="$2"
+
+if [ -d "${CHART_PATH}" ]; then
+    dir="${CHART_PATH}"
+    echo "image tag: ${APP_VERSION}"
+    if [ -f "$dir/Chart.yaml" ]; then
+        chart_name="${dir##*/}"
+        echo "Updating appVersion for Helm chart at $dir"
+    fi
+    if [[ -f "$dir/Chart.yaml" ]] && [[ -f "$dir/values.yaml" ]] && [[ -n "${APP_VERSION}" ]]; then
+        # update/append appVersion in values.yaml
+        if grep "global:" "$dir/values.yaml"; then
+            if grep "appVersion:" "$dir/values.yaml"; then
+                sed -i "$dir/values.yaml" -e "s/appVersion:.*/appVersion: ${APP_VERSION}/"
+            else
+                sed -i "$dir/values.yaml" -e "s/^global\s*$/global:\n  appVersion: ${APP_VERSION}/"
+            fi
+        else
+            echo -e "\nglobal:\n  appVersion: ${APP_VERSION}" >> "$dir/values.yaml"
+        fi
+        cat "$dir/values.yaml"
+
+        # update/append appVersion in Chart.yaml
+        if grep "appVersion:" "$dir/Chart.yaml"; then
+            sed -i "$dir/Chart.yaml" -e "s/appVersion:.*/appVersion: ${APP_VERSION}/"
+        else
+            echo "appVersion: ${APP_VERSION}" >> "$dir/Chart.yaml"
+        fi
+        cat "$dir/Chart.yaml"
+    else
+        echo "WARN: Unable to set global.appVersion in $dir/Chart.yaml - the resulting Chart may not reference a specific image as a result"
+    fi
+fi

--- a/scripts/update-chart-app-version.sh
+++ b/scripts/update-chart-app-version.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+set -ex
+
 CHART_PATH="$1"
 APP_VERSION="$2"
 
@@ -12,12 +36,13 @@ if [ -d "${CHART_PATH}" ]; then
     fi
     if [[ -f "$dir/Chart.yaml" ]] && [[ -f "$dir/values.yaml" ]] && [[ -n "${APP_VERSION}" ]]; then
         # update/append appVersion in values.yaml
-        if grep "global:" "$dir/values.yaml"; then
+        if grep "^\s*global:" "$dir/values.yaml"; then
             if grep "appVersion:" "$dir/values.yaml"; then
-                sed -i "$dir/values.yaml" -e "s/appVersion:.*/appVersion: ${APP_VERSION}/"
+                sed -e "s/^\(\sappVersion:\).*/\1 ${APP_VERSION}/" "$dir/values.yaml" > "$dir/values.yaml.tmp"
             else
-                sed -i "$dir/values.yaml" -e "s/^global\s*$/global:\n  appVersion: ${APP_VERSION}/"
+                sed -e "s/^global\s*$/global:\n  appVersion: ${APP_VERSION}/" "$dir/values.yaml" > "$dir/values.yaml.tmp"
             fi
+            mv "$dir/values.yaml.tmp" "$dir/values.yaml"
         else
             echo -e "\nglobal:\n  appVersion: ${APP_VERSION}" >> "$dir/values.yaml"
         fi
@@ -25,7 +50,8 @@ if [ -d "${CHART_PATH}" ]; then
 
         # update/append appVersion in Chart.yaml
         if grep "appVersion:" "$dir/Chart.yaml"; then
-            sed -i "$dir/Chart.yaml" -e "s/appVersion:.*/appVersion: ${APP_VERSION}/"
+            sed -e "s/appVersion:.*/appVersion: ${APP_VERSION}/" "$dir/Chart.yaml" > "$dir/Chart.yaml.tmp"
+            mv "$dir/Chart.yaml.tmp" "$dir/Chart.yaml"
         else
             echo "appVersion: ${APP_VERSION}" >> "$dir/Chart.yaml"
         fi

--- a/update_appversion/update_appversion.py
+++ b/update_appversion/update_appversion.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+"""
+usage: update_appversion.py <chart_directory> <app_version>
+ 
+In the specified chart directory:
+1) Changes/sets the global appVersion field in values.yaml to
+   the specified app version
+2) Changes/sets the appVersion field in Chart.yaml to the specified version.
+"""
+
+import argparse
+from pathlib import Path
+# Use ruamel because it preserves comments
+from ruamel.yaml import YAML
+import sys
+
+def valid_chart_dir(argstring):
+    """
+    Validates that the specified string is a good directory path.
+    For our purposes, that means that it exists and contains
+    readable files named Chart.yaml and values.yaml.
+    If this is all true, the function returns a pathlib.Path object
+    for the directory.
+    Otherwise an appropriate argparse exception is raised.
+    """
+    dir_path = Path(argstring)
+    if not dir_path.exists():
+        raise argparse.ArgumentTypeError("Path does not exist")
+    elif not dir_path.is_dir():
+        raise argparse.ArgumentTypeError("Path exists but is not a directory")
+    for file_name in [ "Chart.yaml", "values.yaml" ]:
+        file_path = dir_path / file_name
+        if not file_path.exists():
+            raise argparse.ArgumentTypeError("{} not found".format(file_path))
+        elif not file_path.is_file():
+            raise argparse.ArgumentTypeError(
+                "{} found but it is not a regular file".format(file_path))
+        # Finally, make sure we can open it
+        try:
+            file_path.open("rt")
+        except Exception as exc:
+            raise argparse.ArgumentTypeError(
+                "Error opening {file_path}: {exc}".format(file_path=file_path, exc=exc) ) from exc
+    return dir_path
+
+def nonempty_string(argstring):
+    """
+    Validate that the string is not of 0 length.
+    If the string is 0 length, raise an argparse exception.
+    Otherwise return the string.
+    """
+    if argstring:
+        return argstring
+    raise argparse.ArgumentTypeError("appVersion may not be blank")
+
+def parse_args():
+    """
+    Parse the command line arguments. On success, return a pathlib.Path
+    object for the chart directory, and the appVersion string we wish to set.
+    """
+    parser = argparse.ArgumentParser(
+        description="Tool to set appVersion fields in Chart.yaml and values.yaml")
+    parser.add_argument("chart_dir", 
+        metavar="<chart_directory>", 
+        type=valid_chart_dir,
+        help="Directory containing Chart.yaml and values.yaml")
+    parser.add_argument("app_version", 
+        metavar="<app_version>", 
+        type=nonempty_string,
+        help="Value for appVersion fields")
+    args = parser.parse_args()
+    return args.chart_dir, args.app_version
+
+def main(chart_dir, app_version):
+    """
+    The chart_dir argument is a pathlib.Path object for the chart directory.
+    The app_version argument is a string with the value we wish to set the appVersion fields to.
+    Inside the chart directory:
+    1) Changes/sets the global appVersion field in values.yaml to
+       the specified app version
+    2) Changes/sets the appVersion field in Chart.yaml to the specified version.
+    """
+    # Use 'rt' type so we preserve comments in the files
+    yaml = YAML(typ="rt")
+    # Force block-style output
+    yaml.default_flow_style = False
+
+    # values.yaml
+    values_yaml_file = chart_dir / "values.yaml"
+    print("Loading {}".format(values_yaml_file))
+    with values_yaml_file.open("rt"):
+        values_yaml_data = yaml.load(values_yaml_file)
+    # Set the global appVersion to the specified version
+    if "global" in values_yaml_data:
+        values_yaml_data["global"]["appVersion"] = app_version
+        print(
+            "Setting global appVersion to {app_version} in {values_yaml_file}".format(
+                app_version=app_version, values_yaml_file=values_yaml_file))
+    else:
+        # There isn't a global stanza, so we'll create it
+        values_yaml_data["global"] = { "appVersion": app_version }
+        print(
+            "Creating global stanza and setting global appVersion to {app_version} in {values_yaml_file}".format(
+                app_version=app_version, values_yaml_file=values_yaml_file))
+    # Now write back to the file
+    yaml.dump(values_yaml_data, values_yaml_file)
+
+    # Chart.yaml
+    chart_yaml_file = chart_dir / "Chart.yaml"
+    print("Loading {}".format(chart_yaml_file))
+    with chart_yaml_file.open("rt"):
+        chart_yaml_data = yaml.load(chart_yaml_file)
+    # Set appVersion to the specified version
+    chart_yaml_data["appVersion"] = app_version
+    print("Setting appVersion to {app_version} in {chart_yaml_file}".format(app_version=app_version, chart_yaml_file=chart_yaml_file))
+    # Now write back to the file
+    yaml.dump(chart_yaml_data, chart_yaml_file)
+
+    print("Completed updating appVersion in {values_yaml_file} and {chart_yaml_file}".format(
+        values_yaml_file=values_yaml_file, chart_yaml_file=chart_yaml_file))
+
+if __name__ == "__main__":
+    chart_dir, app_version = parse_args()
+    main(chart_dir, app_version)
+    sys.exit(0)

--- a/utils/pyyaml.sh
+++ b/utils/pyyaml.sh
@@ -62,6 +62,85 @@ function pyyaml_validate_dir
     return 0
 }
 
+function pyyaml_pip3_install
+{
+    # Usage: pyyaml_pip3_install <module> [<module>] ...
+    # Assumes PYMODDIR has been set
+    pip3 install "$@" \
+        --no-cache-dir \
+        --trusted-host arti.dev.cray.com \
+        --index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple \
+        --ignore-installed \
+        --target="$PYMODDIR" \
+        --upgrade 1>&2
+}
+
+GET_PIP_DONE=0
+
+function pyyaml_get_pip
+{
+    # Only do this once
+    # Assumes PYMODDIR has been set
+    [[ $GET_PIP_DONE -eq 0 ]] || return
+    
+    # In case this is an alpine container
+    apk add --no-cache python3 > /dev/null 2>&1
+    apk add --no-cache py3-pip > /dev/null 2>&1
+    python3 -m ensurepip 1>&2
+
+    # Get the latest pip, setuptools, and wheel
+    pyyaml_pip3_install pip setuptools wheel
+
+    # Remember that we have already done this
+    GET_PIP_DONE=1
+}
+
+function pyyaml_collect_debug_info
+{
+    # Collect some debug information
+    # Assumes PYMODDIR has been set
+    ls "$PYMODDIR" 1>&2
+    python3 --version 1>&2
+    pip3 --version 1>&2
+    uname -a 1>&2
+    cat /etc/*release* 1>&2
+    pip3 list 1>&2
+}
+
+function pyyaml_install_if_needed
+{
+    # Usage: pyyaml_install_if_needed <module_name_import> [<module_name_pip>]
+    # Assumes PYMODDIR has been set
+    local IMPORT_MOD PIP_MOD
+    IMPORT_MOD="$1"
+    if [ $# -eq 1 ]; then
+        # Assume both names are the same
+        PIP_MOD="$1"
+    else
+        PIP_MOD="$2"
+    fi
+
+    # Test to see if we can import the module
+    pyyaml_info "Checking if Python3 ${PIP_MOD} module is available" 1>&2
+
+    if ! python3 -c "import ${IMPORT_MOD}" >/dev/null 1>&2 ; then
+        pyyaml_info "Installing ${PIP_MOD} into $PYMODDIR" 1>&2
+
+        pyyaml_get_pip
+
+        pyyaml_pip3_install "${PIP_MOD}"
+
+        if ! python3 -c "import ${IMPORT_MOD}" 1>&2 ; then
+            pyyaml_collect_debug_info
+        
+            pyyaml_info "ERROR: Unable to install Python3 ${PIP_MOD} module" 1>&2
+            exit 1
+        fi
+    fi
+
+    pyyaml_info "Python3 ${PIP_MOD} module is available"
+}
+
 # This file assumes that any script sourcing it will have set the variable
 # CMS_META_TOOLS_PATH
 if [ -z "${CMS_META_TOOLS_PATH}" ]; then
@@ -72,43 +151,11 @@ elif ! pyyaml_validate_dir "${CMS_META_TOOLS_PATH}/utils" ; then
     pyyaml_err_exit "utils directory should be in the directory set by CMS_META_TOOLS_PATH"
 fi
 
-# Test to see if yaml module is available
-pyyaml_info "Checking if yaml Python module is available" 1>&2
-
 # Create our local python modules directory, if needed
 PYMODDIR="${CMS_META_TOOLS_PATH}/pymods"
 
 # Add it to our PYTHONPATH variable
 export PYTHONPATH="${PYTHONPATH}:${PYMODDIR}"
 
-if ! python3 -c "import yaml" >/dev/null 1>&2 ; then
-    pyyaml_info "Installing yaml into $PYMODDIR" 1>&2
-
-    # In case this is an alpine container
-    apk add --no-cache python3 > /dev/null 2>&1
-    apk add --no-cache py3-pip > /dev/null 2>&1
-    
-    python3 -m ensurepip 1>&2
-    pip3 install PyYAML \
-        --no-cache-dir \
-        --trusted-host arti.dev.cray.com \
-        --index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple \
-        --ignore-installed \
-        --target="$PYMODDIR" \
-        --upgrade 1>&2
-
-    if ! python3 -c "import yaml" 1>&2 ; then
-        # Collect some debug information
-        ls "$PYMODDIR" 1>&2
-        python3 --version 1>&2
-        pip3 --version 1>&2
-        uname -a 1>&2
-        cat /etc/*release* 1>&2
-        pip3 list 1>&2
-
-        pyyaml_info "ERROR: Unable to install Python yaml module" 1>&2
-        exit 1
-    fi
-fi
-
-pyyaml_info "Python yaml module is available"
+pyyaml_install_if_needed yaml PyYAML
+pyyaml_install_if_needed ruamel.yaml

--- a/version.py
+++ b/version.py
@@ -48,7 +48,6 @@ from distutils.version import LooseVersion
 
 THIS_FILE = __file__
 THIS_PROJECT = os.getcwd()
-BRANCH_PATTERN = re.compile("^\*\s(.*?)\s", re.M)
 
 def myprint(s):
     """
@@ -60,13 +59,7 @@ def branch_name():
     """
     Obtains a copy of the name of the current branch; make it work with all DST build pipelines.
     """
-    output = subprocess.check_output(['git', 'branch'], cwd=THIS_PROJECT).decode('UTF-8')
-    try:
-        return BRANCH_PATTERN.search(output).groups()[0]
-    except AttributeError:
-        # DST Build pipelines don't allow us to query the name of the version all the time.
-        # So, we can find it in the environment.
-        return os.environ.get('GIT_BRANCH', None)
+    return subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=THIS_PROJECT).decode('UTF-8')
 
 class VersionStrategy():
     """


### PR DESCRIPTION
## Summary and Scope

Some non-CMS teams are using the RPM produced by the release/cmt-2.0 branch. Therefore we should ideally keep that branch up-to-date (except for things which break backward-compatibility, of course).

Specifically, this pulls in:
* Adding this PR template
* Modifying how version.py detects the build branch
* Modify git_info.sh to handle existing chart annotations properly
* Create update_appversion tool to append global appVersion to kubernetes charts
* Fix to latest_version.py so it sorts versions with underscore-separated build metadata (CASMTRIAGE-2738)

## Issues and Related PRs

See above.

## Testing

The testing for each of the above items was done with their original PRs.

## Risks and Mitigations

Low risk. It's riskier not to keep this branch up to date. I'm currently working on a bug reported by another team that uses this tool, so as a baseline I want to make sure they're running the latest version.

## Pull Request Checklist

- [NA ] Version number(s) incremented, if applicable
- [NA] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [NA] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

