### PR TITLE
CASMTRIAGE-2738: latest_version: Allow underscore for build metadata in version sort

### DIFF
--- a/latest_version/latest_version.py
+++ b/latest_version/latest_version.py
@@ -179,10 +179,16 @@ def compare_identifiers(a, b):
         return 0
 
 def remove_build(s):
+    # The build metadata string may be separated using either an underscore or a plus
     try:
         return s[:s.index('+')]
     except ValueError:
-        return s
+        # No + was found. Try _
+        try:
+            return s[:s.index('_')]
+        except ValueError:
+            # This means there was no build metadata to remove
+            return s
 
 def get_version_and_prerelease(s):
     try:


### PR DESCRIPTION
## Summary and Scope

CASMTRIAGE-2738 was opened because latest_version.py was not correctly returning the latest version -- it was returning a version, but not the latest. Investigation revealed that the functions responsible for sorting the versions was hard-coded to assume that build metadata strings would be appended with a plus character. That is accurate for SemVer 2.0, but our version strings often use underscores for this purpose instead. The tool was supposed to handle this, and in fact the regular expression it used to filter out illegal version strings properly allowed for it, but the version sorting functions did not.

This PR corrects the version sorting function so that it allows for build metadata to be appended with a plus or an underscore.

## Issues and Related PRs

This will be pulled into the release/cmt-2.0 branch with this PR:
https://github.com/Cray-HPE/cms-meta-tools/pull/17

## Testing

I tested latest_version.py in a Python 3.5 virtual environment and a Python 3.8 virtual environment (because during the course of this investigation we noted divergent behavior of the tool between those two Python versions -- this PR also corrects that, as a side-effect).

## Risks and Mitigations

Low risk. For many version checks, the change will make no difference. It only matters when two versions are identical except for build metadata.

## Pull Request Checklist

- [NA] Version number(s) incremented, if applicable
- [NA] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [NA] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

