### PR TITLE
Fix gitversion - turn off CICD normalization and ensure main/develop branches

### DIFF
--- a/vars/setVersionFiles.groovy
+++ b/vars/setVersionFiles.groovy
@@ -44,8 +44,22 @@ def call() {
     if (fileExists('GitVersion.yml')) {
         // Using gitversion versioning
         echo "GitVersion.yml file exists -- using gitversion versioning"
+        echo "Ensuring local develop and master branches"
+        branches = sh(returnStdout: true, script: "git branch -r --color=never").split("\n").collect{it.strip()}
+        if ( branches.find{it=="origin/main"} ) {
+            sh "git branch main --track origin/main"
+        } else if ( branches.find{it=="origin/master"} ) {
+            sh "git branch master --track origin/master"
+        } else {
+            error "Cloned repository is missing master or main branch, required for gitversion functionality"
+        }
+        if ( branches.find{it=="origin/develop"} ) {
+            sh "git branch develop --track origin/develop"
+        } else {
+            error "Cloned repository is missing develop or main branch, required for gitversion functionality"
+        }
         echo "Reading base version from gitversion"
-        ver = sh(returnStdout: true, script: "gitversion /output json /showvariable SemVer").trim()
+        ver = sh(returnStdout: true, script: "gitversion /output json /showvariable SemVer /nonormalize").trim()
         echo "Writing base version to .version"
         writeFile(file: ".version", text: ver)
     } else {


### PR DESCRIPTION
## Summary and Scope

Fix the issue with gitversion throwing the following error:
    
    21:00:36  + gitversion /output json /showvariable SemVer
    21:00:36  INFO [05/02/22 21:00:36:49] Applicable build agent found: 'Jenkins'.
    21:00:36  INFO [05/02/22 21:00:36:53] Working directory: /home/jenkins/workspace/ims-utils_feature_mtupitsyn-test
    21:00:36  INFO [05/02/22 21:00:36:56] Project root is: /home/jenkins/workspace/ims-utils_feature_mtupitsyn-test/
    21:00:36  INFO [05/02/22 21:00:36:56] DotGit directory is: /home/jenkins/workspace/ims-utils_feature_mtupitsyn-test/.git
    21:00:36  INFO [05/02/22 21:00:36:56] Branch from build environment: feature/mtupitsyn-test
    21:00:36  INFO [05/02/22 21:00:36:56] Begin: Normalizing git directory for branch 'feature/mtupitsyn-test'
    21:00:36    INFO [05/02/22 21:00:36:58] One remote found (origin -> 'https://github.com/Cray-HPE/ims-utils.git').
    21:00:36    INFO [05/02/22 21:00:36:59] Skipping fetching, if GitVersion does not calculate your version as expected you might need to allow fetching or use dynamic repositories
    21:00:36    INFO [05/02/22 21:00:36:59] Updating local branch feature/mtupitsyn-test to match ref feature/mtupitsyn-test
    21:00:36    INFO [05/02/22 21:00:36:61] Creating local branch from remote tracking 'refs/remotes/origin/CASMCMS-7676'.
    21:00:36    INFO [05/02/22 21:00:36:62] End: Normalizing git directory for branch 'feature/mtupitsyn-test' (Took: 58.18ms)
    21:00:36    ERROR [05/02/22 21:00:36:65] An unexpected error occurred:
    21:00:36  LibGit2Sharp.LibGit2SharpException: ref 'refs/remotes/origin/CASMCMS-7676' doesn't match the destination

## Issues and Related PRs

* Resolves [CASMCMS-7937](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7937)

## Testing

### Tested on:

  * Jenkins

### Test description:

I created a temporary branch `feature/mtupitsyn-test` in `ims-utils` project, and updated  `@Library` annotation to use branch `feature/fix-gitversion` of `cms-meta-tools` shared library:
https://github.com/Cray-HPE/ims-utils/commit/e11003a21458ef7b1ec977f458825ce779d3d87f

Build on this branch is successful, and it determined version as `2.7.0-mtupitsyn-test.1-20220502215117_e11003a`:
https://jenkins.algol60.net/job/Cray-HPE/job/ims-utils/job/feature%252Fmtupitsyn-test/7/console

## Risks and Mitigations

Low - build system issue resolution/

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

